### PR TITLE
Add poor high/low extension lines

### DIFF
--- a/btc_mp_v1.py
+++ b/btc_mp_v1.py
@@ -243,6 +243,32 @@ def update_graph(n, value):
                 width=1,
                 dash="dashdot", ), )
 
+        if getattr(irank, 'poor_high', False):
+            ph_color = 'yellow'
+            if getattr(irank, 'poor_high_unresolved', False):
+                ph_color = 'red'
+                print(f"Poor high {irank.poor_high_price} on {irank.date} not intersected within 4 days")
+            fig.add_shape(
+                type="line",
+                x0=df_mp.index[0],
+                y0=irank.poor_high_price,
+                x1=df3.index[-1],
+                y1=irank.poor_high_price,
+                line=dict(color=ph_color, width=1, dash="dot"), )
+
+        if getattr(irank, 'poor_low', False):
+            pl_color = 'yellow'
+            if getattr(irank, 'poor_low_unresolved', False):
+                pl_color = 'red'
+                print(f"Poor low {irank.poor_low_price} on {irank.date} not intersected within 4 days")
+            fig.add_shape(
+                type="line",
+                x0=df_mp.index[0],
+                y0=irank.poor_low_price,
+                x1=df3.index[-1],
+                y1=irank.poor_low_price,
+                line=dict(color=pl_color, width=1, dash="dot"), )
+
     fig.layout.xaxis.type = 'category'  # This line will omit annoying weekends on the plotly graph
 
     ltp = df1.iloc[-1]['Close']


### PR DESCRIPTION
## Summary
- detect poor highs/lows in TPO analysis
- flag untested poor highs/lows older than 4 days
- show extension lines for poor highs/lows in dashboard

## Testing
- `python -m py_compile MP.py btc_mp_v1.py`

------
https://chatgpt.com/codex/tasks/task_e_684123f794fc8332878f7113820daf0d